### PR TITLE
[Fix] Compilation failure with Xcode 12.5 and SPM

### DIFF
--- a/Source/cmark/inlines.h
+++ b/Source/cmark/inlines.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <references.h>
+
 cmark_chunk cmark_clean_url(cmark_mem *mem, cmark_chunk *url);
 cmark_chunk cmark_clean_title(cmark_mem *mem, cmark_chunk *title);
 


### PR DESCRIPTION
After updating to Xcode 12.5, the Down framework no longer builds (at least when used through the Swift Package Manager.) The compiler error message is:

Unknown type name 'cmark_reference_map' inlines.h 

Including the file references.h in inlines.h fixes the problem. This is a quick and dirty fix. Ideally, it shouldn't be necessary to modify the CommonMark code to fix this.