### PR TITLE
[Chore] Add arm64 as valid arch when building for simulator on M1 macs

### DIFF
--- a/Down.xcodeproj/project.pbxproj
+++ b/Down.xcodeproj/project.pbxproj
@@ -1071,6 +1071,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "${SRCROOT}/Source/cmark";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64 arm64";
 			};
 			name = Debug;
 		};
@@ -1092,6 +1093,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "${SRCROOT}/Source/cmark";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64 arm64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
this pr allows building and linking `Down` when running on arm64 simulator

Error message without this:
```
Could not find module 'Down' for target 'arm64-apple-ios-simulator'; found: x86_64-apple-ios-simulator, x86_64
```